### PR TITLE
Allow route decorators to receive array of middlewares as param

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -1,15 +1,20 @@
 const PREFIX = '$$route_'
 
+function flatten(arr) {
+  return Array.prototype.concat(...arr);
+}
+
 function destruct(args) {
   const hasPath = typeof args[0] === 'string'
   const path = hasPath ? args[0] : ''
   const middleware = hasPath ? args.slice(1) : args
+  const flattenedMiddleware = flatten(middleware)
 
-  if (middleware.some(m => typeof m !== 'function')) {
+  if (flattenedMiddleware.some(m => typeof m !== 'function')) {
     throw new Error('Middleware must be function')
   }
 
-  return [path, middleware]
+  return [path, flattenedMiddleware]
 }
 
 // @route(method, path: optional, ...middleware: optional)

--- a/test/decorators.spec.js
+++ b/test/decorators.spec.js
@@ -5,6 +5,7 @@ function m1() {}
 function m2() {}
 function m3() {}
 function m4() {}
+function m5() {}
 
 describe('controller', () => {
   const {controller, route, all, get, post, del} = decorators
@@ -83,4 +84,15 @@ describe('controller', () => {
       {url: '/users/delete', middleware: [m1, m2, m3, m4], method: 'delete', fnName: '_delete'}
     ])
   })
+
+  it('should define correct $routes when paths and array of middlewares are specified', () => {
+    @controller('/users', m1, m2)
+    class Ctrl {
+      @post('/post', [m3, m4], m5) _post() {}
+    }
+
+    assert.deepEqual((new Ctrl()).$routes, [
+      {url: '/users/post', middleware: [m1, m2, m3, m4, m5], method: 'post', fnName: '_post'},
+    ])
+  });
 })


### PR DESCRIPTION
Sometimes we need to define a set of middlewares to present a functionality. For example, `useAuth` middleware can be composed of [useJWT(), useMongoDB(), useUser()]. 

This PR is to allow route decorators to be easier to work within those cases.